### PR TITLE
Add buffersize support

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function execute(args, callback, buffersize) {
 			return callback(err)
 		}
 
-		var cpArgs = buffersize === undefined ? { maxBuffer: buffersize } : {};
+		var cpArgs = buffersize === undefined ? {} : { maxBuffer: buffersize };
 
 		childProcess.execFile(cscript.path(), args, cpArgs, function (err, stdout, stderr) {
 


### PR DESCRIPTION
Assuming that you'd want a parameter passed into every function, optional, stating the buffer size.
Fixes #72.